### PR TITLE
Preparación para el envío a la tienda de NV Access

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -25,7 +25,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description": _("Módulo que agrega enfoques automáticos y atajos de teclado a funciones importantes de la aplicación"),
 	# version
-	"addon_version": "2.0",
+	"addon_version": "2.0.0",
 	# Author(s)
 	"addon_author": "Gerardo Kessler <ReaperYOtrasYerbas@gmail.com>",
 	# URL for the add-on documentation support
@@ -33,13 +33,19 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": "2022.4",
+	"addon_minimumNVDAVersion": "2022.4.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.1",
+	"addon_lastTestedNVDAVersion": "2023.1.0",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!
 	"addon_updateChannel": None,
+	# Add-on license such as GPL 2
+	"addon_license": "GPL 2",
+	# URL for the license document the ad-on is licensed under
+	"addon_licenseURL": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html",
+	# URL for the add-on repository where the source code can be found
+	"addon_sourceURL": "https://github.com/gerardKessler/unigram"
 }
 
 # Define the python files that are the sources of your add-on.

--- a/sconstruct
+++ b/sconstruct
@@ -1,5 +1,5 @@
 # NVDA add-on template  SCONSTRUCT file
-# Copyright (C) 2012-2021 Rui Batista, Noelia Martinez, Joseph Lee
+# Copyright (C) 2012-2023 Rui Batista, Noelia Martinez, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING.txt for more details.
 
@@ -75,8 +75,21 @@ def mdTool(env):
 	env['BUILDERS']['markdown'] = mdBuilder
 
 
+def validateVersionNumber(key, val, env):
+	# Used to make sure version major.minor.patch are integers to comply with NV Access add-on store.
+	# Ignore all this if version number is not specified, in which case json generator will validate this info.
+	if val == "0.0.0":
+		return
+	versionNumber = val.split(".")
+	if len(versionNumber) < 3:
+		raise ValueError("versionNumber must have three parts (major.minor.patch)")
+	if not all([part.isnumeric() for part in versionNumber]):
+		raise ValueError("versionNumber (major.minor.patch) must be integers")
+
+
 vars = Variables()
 vars.Add("version", "The version of this build", buildVars.addon_info["addon_version"])
+vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0", validateVersionNumber)
 vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
 vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
@@ -87,7 +100,9 @@ if env["dev"]:
 	import datetime
 	buildDate = datetime.datetime.now()
 	year, month, day = str(buildDate.year), str(buildDate.month), str(buildDate.day)
-	env["addon_version"] = "".join([year, month.zfill(2), day.zfill(2), "-dev"])
+	versionTimestamp = "".join([year, month.zfill(2), day.zfill(2)])
+	env["addon_version"] = f"{versionTimestamp}-dev"
+	env["versionNumber"] = f"{versionTimestamp}.0.0"
 	env["channel"] = "dev"
 elif env["version"] is not None:
 	env["addon_version"] = env["version"]
@@ -155,7 +170,83 @@ def createAddonBundleFromPath(path, dest):
 				absPath = os.path.join(dir, filename)
 				if pathInBundle not in buildVars.excludedFiles:
 					z.write(absPath, pathInBundle)
+	createAddonStoreJson(dest)
 	return dest
+
+
+def createAddonStoreJson(bundle):
+	"""Creates add-on store JSON file from an add-on package and manifest data."""
+	import json
+	import hashlib
+	# Set different json file names and version number properties based on version number parsing results.
+	if env["versionNumber"] == "0.0.0":
+		env["versionNumber"] = buildVars.addon_info["addon_version"]
+	versionNumberParsed = env["versionNumber"].split(".")
+	if all([part.isnumeric() for part in versionNumberParsed]):
+		if len(versionNumberParsed) == 1:
+			versionNumberParsed += ["0", "0"]
+		elif len(versionNumberParsed) == 2:
+			versionNumberParsed.append("0")
+	else:
+		versionNumberParsed = []
+	if len(versionNumberParsed):
+		major, minor, patch = [int(part) for part in versionNumberParsed]
+		jsonFilename = f'{major}.{minor}.{patch}.json'
+	else:
+		jsonFilename = f'{buildVars.addon_info["addon_version"]}.json'
+		major, minor, patch = 0, 0, 0
+	print('Generating % s' % jsonFilename)
+	sha256 = hashlib.sha256()
+	with open(bundle, "rb") as f:
+		for byte_block in iter(lambda: f.read(65536), b""):
+			sha256.update(byte_block)
+	hashValue = sha256.hexdigest()
+	try:
+		minimumNVDAVersion = buildVars.addon_info["addon_minimumNVDAVersion"].split(".")
+	except AttributeError:
+		minimumNVDAVersion = [0, 0, 0]
+	minMajor, minMinor = minimumNVDAVersion[:2]
+	minPatch = minimumNVDAVersion[-1] if len(minimumNVDAVersion) == 3 else "0"
+	try:
+		lastTestedNVDAVersion = buildVars.addon_info["addon_lastTestedNVDAVersion"].split(".")
+	except AttributeError:
+		lastTestedNVDAVersion = [0, 0, 0]
+	lastTestedMajor, lastTestedMinor = lastTestedNVDAVersion[:2]
+	lastTestedPatch = lastTestedNVDAVersion[-1] if len(lastTestedNVDAVersion) == 3 else "0"
+	channel = buildVars.addon_info["addon_updateChannel"]
+	if channel is None:
+		channel = "stable"
+	addonStoreEntry = {
+		"addonId": buildVars.addon_info["addon_name"],
+		"displayName": buildVars.addon_info["addon_summary"],
+		"URL": "",
+		"description": buildVars.addon_info["addon_description"],
+		"sha256": hashValue,
+		"homepage": buildVars.addon_info["addon_url"],
+		"addonVersionName": buildVars.addon_info["addon_version"],
+		"addonVersionNumber": {
+			"major": major,
+			"minor": minor,
+			"patch": patch
+		},
+		"minNVDAVersion": {
+			"major": int(minMajor),
+			"minor": int(minMinor),
+			"patch": int(minPatch)
+		},
+		"lastTestedVersion": {
+			"major": int(lastTestedMajor),
+			"minor": int(lastTestedMinor),
+			"patch": int(lastTestedPatch)
+		},
+		"channel": channel,
+		"publisher": "",
+		"sourceURL": buildVars.addon_info["addon_sourceURL"],
+		"license": buildVars.addon_info["addon_license"],
+		"licenseURL": buildVars.addon_info["addon_licenseURL"],
+	}
+	with open(jsonFilename, "w") as addonStoreJson:
+		json.dump(addonStoreEntry, addonStoreJson, indent="\t")
 
 
 def generateManifest(source, dest):


### PR DESCRIPTION
En esta pull request, te actualizo la plantilla de complementos a la última versión, adaptando los ficheros buildVars.py y sconstruct. Además, he cambiado el número de versión a 2.0.0. Independientemente del esquema que decidas seguir, la tienda espera encontrar una versión compuesta de 3 números enteros, separados por punto y sin ningún otro carácter.
Una vez que fusiones la pull request pulsando en Merge y luego en Confirm merge, sigue estos pasos:

* Prepara una release nueva, la 2.0.0.
* Abre un issue en [este repositorio](https://github.com/nvaccess/addon-datastore/issues). Busca el botón New issue y púlsalo.
* Te dará a elegir una plantilla llamada Add-on registration, o bien crear una incidencia en blanco. Elige la primera pulsando un enlace llamado Get started.
* Llegarás a un formulario con varios campos. Rellénalos del siguiente modo:

1. Title: [Submit add-on]: Unigram 2.0.0
2. Download URL: el enlace directo a tu archivo .nvda-addon publicado en la release de GitHub.
3. Source URL: la URL de este repositorio.
4. Publisher: tu nombre de usuario de GitHub.

El resto lo puedes dejar como está. En cuanto abras la incidencia, se iniciará un proceso automático que dará como resultado la incidencia cerrada y una pull request fusionada. A partir de entonces, tu complemento estará disponible en la tienda.
Suerte.